### PR TITLE
Add helper to read login information from authinfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,23 @@ of Grammarly!
 (setq grammarly-password "password")  ; Your Grammarly Password
 ```
 
+If you use `auth-source` to manage your secrets, you can add this to your
+`.authinfo.gpg` file:
+
+``` 
+machine grammarly.com login <your@email.com> pass <your-password>
+```
+
+And instead of directly setting `grammarly-username` and `grammarly-password`, 
+you can call the helper function `grammarly-load-from-authinfo`.
+
+``` el
+(grammarly-load-from-authinfo)
+
+;; Or, if you have multiple Grammarly accounts:
+(grammarly-load-from-authinfo "your@email.com")
+```
+
 ## References
 
 * [grammarly-api](https://github.com/dexterleng/grammarly-api)

--- a/grammarly.el
+++ b/grammarly.el
@@ -156,6 +156,18 @@
    ((listp lst) (dolist (fnc lst) (apply fnc args)))
    (t (user-error "[ERROR] Function does not exists: %s" lst))))
 
+(defun grammarly-load-from-authinfo (&optional username)
+  "Load Grammarly authentication info from auth-source. Optionally pass the USERNAME, otherwise, it will be searched in the authinfo file.
+You will need to add a line in your authinfo file \"machine grammarly.com login <YOUR-EMAIL> pass <YOUR-PASSWORD>\"."
+  (require 'auth-source)
+  (let ((user-info (car (auth-source-search :host "grammarly.com" :user username))))
+    (when user-info
+      (let ((user (or username (plist-get user-info :user)))
+            (secret (plist-get user-info :secret)))
+        (when (and user secret)
+          (setq grammarly-username user
+                grammarly-password (funcall secret)) t)))))
+
 ;;
 ;; (@* "Cookie" )
 ;;


### PR DESCRIPTION
Hello and thank you for this package!

Here is a PR to add the possibility to load login info from `.authinfo` file via the `grammarly-load-from-authinfo` helper function.

The file should include a line like this:

`machine grammarly.com login <YOUR-EMAIL> pass <YOUR-PASSWORD>`